### PR TITLE
update kwargs for python3.9 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Celery support is also included.
 
 - Python3.6.0+
 - Django 2.0.0+
-- psycopg2 2.7.0+
+- psycopg2 3.2.0+
 
 Optional requirements:
 

--- a/msg/models.py
+++ b/msg/models.py
@@ -1,7 +1,6 @@
 from enum import Enum
 from typing import Union
 
-from django.contrib.postgres.fields import JSONField
 from django.db import models
 from django.utils import translation
 from django.utils.translation import ugettext_lazy as _
@@ -73,10 +72,10 @@ class Msg(models.Model):
         verbose_name=_('Language'),
         max_length=32,
     )
-    recipients = JSONField(
+    recipients = models.JSONField(
         verbose_name=_('Recipients'),
     )
-    context = JSONField(
+    context = models.JSONField(
         verbose_name=_('Context'),
         default={},
         blank=True,
@@ -93,11 +92,11 @@ class Msg(models.Model):
     objects = MsgManager()
 
     @staticmethod
-    def new(*args, dispatch_now, async=msg_settings.async, **kwargs):
+    def new(*args, dispatch_now, _async=msg_settings._async, **kwargs):
         msg = Msg.objects.create_from_any(*args, **kwargs)
 
         if dispatch_now:
-            msg.dispatch(async=async)
+            msg.dispatch(_async=_async)
 
         return msg
 
@@ -107,9 +106,9 @@ class Msg(models.Model):
         if save:
             self.save()
 
-    def dispatch(self, async=msg_settings.async):
+    def dispatch(self, _async=msg_settings._async):
         self.set_status(Msg.Status.PENDING, save=True)
-        if async:
+        if _async:
             self._dispatch_delay()
         else:
             self._dispatch()

--- a/msg/settings.py
+++ b/msg/settings.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from .utils import import_from_string
 
 DEFAULT_SETTINGS = {
-    'async': False,
+    '_async': False,
     'handlers': [],
     'default_lang': 'en',
 }

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author='Jędrzej Rosłaniec',
     author_email='jedr.ros@gmail.com',
     license='MIT',
-    install_requires=['django >= 2.0.0', 'psycopg2 >= 2.7.0'],
+    install_requires=['django >= 3.2.0', 'psycopg2 >= 2.7.0'],
     extras_require={
         'celery': ['celery >= 4.0.0'],
         'boto3': ['boto3 >= 1.0.0'],


### PR DESCRIPTION
* `async` is a reserved key word in Python3.7+
* Also updates models.py to use models.JSONField since the import is deprecated